### PR TITLE
ci: add PathProbe CI

### DIFF
--- a/.github/workflows/probe-ci.yml
+++ b/.github/workflows/probe-ci.yml
@@ -1,0 +1,15 @@
+name: PathProbe CI
+on:
+  push:
+    branches: ['lab/pp-*']
+  pull_request:
+    branches: ['lab/pp-*']
+permissions:
+  contents: read
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./actions/probe-ci
+


### PR DESCRIPTION
Add PathProbe CI using local reusable action at ./actions/probe-ci. Triggers on lab/pp-*.