### PR TITLE
ci: fix probe import path and artifact name

### DIFF
--- a/actions/probe-ci/action.yml
+++ b/actions/probe-ci/action.yml
@@ -14,5 +14,5 @@ runs:
         ./probe_run.sh
     - uses: actions/upload-artifact@v4
       with:
-        name: probe-${{ github.ref_name }}
+        name: probe-${{ replace(github.ref_name, '/', '-') }}
         path: experiments/pathprobe/**/probe_report.json

--- a/experiments/pathprobe/probe_run.sh
+++ b/experiments/pathprobe/probe_run.sh
@@ -18,6 +18,9 @@ for D in */; do
 
   mkdir -p .probe
 
+  # Ensure local package imports (e.g., `import impl`) resolve
+  export PYTHONPATH=.:${PYTHONPATH:-}
+
   # Tests
   pytest -q --maxfail=1 --disable-warnings \
     --json-report --json-report-file=.probe/pytest.json || true


### PR DESCRIPTION
- Export PYTHONPATH in probe_run.sh so tests can import impl\n- Sanitize artifact name to avoid slash in upload-artifact\n