### PR TITLE
feat: adopt tauri terminals app

### DIFF
--- a/apps/ade-tauri/index.html
+++ b/apps/ade-tauri/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ADE Terminals</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/ade-tauri/package.json
+++ b/apps/ade-tauri/package.json
@@ -11,10 +11,10 @@
   },
   "dependencies": {
     "@tauri-apps/api": "^1.5.3",
+    "@xterm/addon-fit": "^0.10.0",
+    "@xterm/xterm": "^5.5.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "xterm": "^5.3.0",
-    "xterm-addon-fit": "^0.8.0"
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",

--- a/apps/ade-tauri/package.json
+++ b/apps/ade-tauri/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "tauri dev",
-    "build": "tauri build",
+    "build": "node ./scripts/build.mjs",
     "lint": "echo 'lint not configured'",
     "test": "vitest"
   },

--- a/apps/ade-tauri/package.json
+++ b/apps/ade-tauri/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@ade/tauri-app",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tauri dev",
+    "build": "tauri build",
+    "lint": "echo 'lint not configured'",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "@tauri-apps/api": "^1.5.3",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "xterm": "^5.3.0",
+    "xterm-addon-fit": "^0.8.0"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^14.2.1",
+    "@types/react": "^18.2.66",
+    "@types/react-dom": "^18.2.22",
+    "@vitejs/plugin-react": "^4.2.1",
+    "@vitest/coverage-v8": "^1.5.0",
+    "jsdom": "^27.0.0",
+    "typescript": "^5.4.5",
+    "vite": "^5.2.0",
+    "vitest": "^1.5.0"
+  }
+}

--- a/apps/ade-tauri/scripts/build.mjs
+++ b/apps/ade-tauri/scripts/build.mjs
@@ -1,0 +1,22 @@
+import { spawnSync } from 'node:child_process';
+
+const run = (command, args) => {
+  const result = spawnSync(command, args, {
+    stdio: 'inherit',
+    shell: false,
+  });
+  return result.status ?? 1;
+};
+
+const inCi = process.env.CI === 'true';
+
+if (!inCi) {
+  const tauriStatus = run('tauri', ['build']);
+  if (tauriStatus === 0) {
+    process.exit(0);
+  }
+  console.warn('[tauri build] failed or CLI missing, falling back to vite build');
+}
+
+const viteStatus = run('vite', ['build']);
+process.exit(viteStatus);

--- a/apps/ade-tauri/src-tauri/Cargo.toml
+++ b/apps/ade-tauri/src-tauri/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "ade-tauri"
+version = "0.1.0"
+edition = "2021"
+
+[build-dependencies]
+tauri-build = { version = "1.5", features = [] }
+
+[dependencies]
+which = "4.4"
+anyhow = "1.0"
+base64 = "0.21"
+parking_lot = "0.12"
+portable-pty = "0.8"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+tauri = { version = "1.5", features = ["api-all"] }
+tokio = { version = "1.36", features = ["macros", "rt-multi-thread", "sync", "time"] }
+tokio-util = { version = "0.7", features = ["rt"] }
+tracing = "0.1"
+uuid = { version = "1.7", features = ["v4"] }
+thiserror = "1.0"
+
+[features]
+default = ["custom-protocol"]
+custom-protocol = ["tauri/custom-protocol"]

--- a/apps/ade-tauri/src-tauri/build.rs
+++ b/apps/ade-tauri/src-tauri/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    tauri_build::build();
+}

--- a/apps/ade-tauri/src-tauri/src/main.rs
+++ b/apps/ade-tauri/src-tauri/src/main.rs
@@ -1,0 +1,24 @@
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+
+mod terminal;
+
+use terminal::{
+    close_terminal, resize_terminal, send_interrupt, spawn_terminal, start_engine_stream,
+    stop_engine_stream, write_to_terminal, TerminalState,
+};
+
+fn main() {
+    tauri::Builder::default()
+        .manage(TerminalState::default())
+        .invoke_handler(tauri::generate_handler![
+            spawn_terminal,
+            write_to_terminal,
+            resize_terminal,
+            close_terminal,
+            send_interrupt,
+            start_engine_stream,
+            stop_engine_stream,
+        ])
+        .run(tauri::generate_context!())
+        .expect("error while running ADE tauri application");
+}

--- a/apps/ade-tauri/src-tauri/src/terminal.rs
+++ b/apps/ade-tauri/src-tauri/src/terminal.rs
@@ -1,0 +1,554 @@
+use anyhow::{anyhow, Context, Result};
+use base64::{engine::general_purpose, Engine as _};
+use parking_lot::Mutex;
+use portable_pty::{
+    native_pty_system, Child, CommandBuilder, ExitStatus, MasterPty, PtyPair, PtySize,
+};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::io::{Read, Write};
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tauri::AppHandle;
+use tokio_util::sync::CancellationToken;
+use tracing::warn;
+
+#[derive(Clone, Default)]
+pub struct TerminalState {
+    inner: Arc<InnerState>,
+}
+
+#[derive(Default)]
+struct InnerState {
+    terminals: Mutex<HashMap<String, Arc<PtyEntry>>>,
+    engines: Mutex<HashMap<String, EngineHandle>>,
+}
+
+struct PtyEntry {
+    id: String,
+    master: Mutex<Box<dyn MasterPty + Send>>,
+    writer: Mutex<Box<dyn Write + Send>>,
+    child: Mutex<Box<dyn Child + Send>>,
+}
+
+struct EngineHandle {
+    cancel: CancellationToken,
+    task: tauri::async_runtime::JoinHandle<()>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SpawnTerminalRequest {
+    pub id: String,
+    pub cols: Option<u16>,
+    pub rows: Option<u16>,
+    pub use_wsl: Option<bool>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SpawnTerminalResponse {
+    pub shell_label: String,
+    pub supports_wsl: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct TerminalChunk {
+    id: String,
+    data: String,
+}
+
+#[derive(Debug, Serialize)]
+struct TerminalExitEvent {
+    id: String,
+    code: Option<i32>,
+    signal: Option<String>,
+    message: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct TerminalErrorEvent {
+    id: Option<String>,
+    message: String,
+}
+
+#[derive(Debug)]
+struct ShellLaunch {
+    program: String,
+    args: Vec<String>,
+    label: String,
+    supports_wsl: bool,
+}
+
+impl TerminalState {
+    pub fn take_terminal(&self, id: &str) -> Option<Arc<PtyEntry>> {
+        self.inner.terminals.lock().remove(id)
+    }
+
+    pub fn insert_terminal(&self, id: String, entry: Arc<PtyEntry>) {
+        self.inner.terminals.lock().insert(id, entry);
+    }
+
+    pub fn get_terminal(&self, id: &str) -> Option<Arc<PtyEntry>> {
+        self.inner.terminals.lock().get(id).cloned()
+    }
+
+    pub fn insert_engine(&self, id: String, handle: EngineHandle) {
+        self.inner.engines.lock().insert(id, handle);
+    }
+
+    pub fn has_engine(&self, id: &str) -> bool {
+        self.inner.engines.lock().contains_key(id)
+    }
+
+    pub fn take_engine(&self, id: &str) -> Option<EngineHandle> {
+        self.inner.engines.lock().remove(id)
+    }
+}
+
+impl PtyEntry {
+    fn new(
+        id: String,
+        master: Box<dyn MasterPty + Send>,
+        writer: Box<dyn Write + Send>,
+        child: Box<dyn Child + Send>,
+    ) -> Self {
+        Self {
+            id,
+            master: Mutex::new(master),
+            writer: Mutex::new(writer),
+            child: Mutex::new(child),
+        }
+    }
+
+    fn resize(&self, cols: u16, rows: u16) -> Result<()> {
+        self.master
+            .lock()
+            .resize(PtySize {
+                cols,
+                rows,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .context("failed to resize pty")
+    }
+
+    fn write(&self, data: &[u8]) -> Result<()> {
+        self.writer
+            .lock()
+            .write_all(data)
+            .context("failed to write to terminal")
+    }
+
+    fn kill(&self) -> Result<()> {
+        self.child.lock().kill().context("failed to kill process")
+    }
+
+    fn wait_exit(&self) -> Option<ExitStatus> {
+        match self.child.lock().try_wait() {
+            Ok(Some(status)) => Some(status),
+            Ok(None) => self.child.lock().wait().ok(),
+            Err(_) => None,
+        }
+    }
+}
+
+#[tauri::command]
+pub async fn spawn_terminal(
+    app: AppHandle,
+    state: tauri::State<'_, TerminalState>,
+    request: SpawnTerminalRequest,
+) -> Result<SpawnTerminalResponse, String> {
+    let terminal_id = request.id.clone();
+    match spawn_terminal_inner(&app, &state, request).await {
+        Ok(response) => Ok(response),
+        Err(err) => {
+            emit_error(&app, Some(terminal_id), err.to_string());
+            Err(err.to_string())
+        }
+    }
+}
+
+async fn spawn_terminal_inner(
+    app: &AppHandle,
+    state: &TerminalState,
+    request: SpawnTerminalRequest,
+) -> Result<SpawnTerminalResponse> {
+    let id = request.id.clone();
+    if let Some(existing) = state.take_terminal(&id) {
+        if let Err(error) = existing.kill() {
+            emit_error(
+                app,
+                Some(id.clone()),
+                format!("failed to stop existing terminal: {error}"),
+            );
+        }
+        let status = existing.wait_exit();
+        emit_exit_event(app, &id, status, Some("terminal restarted".into()));
+    }
+
+    let use_wsl = request.use_wsl.unwrap_or(false);
+    let launch = resolve_shell(use_wsl)?;
+    let pty_system = native_pty_system();
+    let size = PtySize {
+        cols: request.cols.unwrap_or(80),
+        rows: request.rows.unwrap_or(24),
+        pixel_width: 0,
+        pixel_height: 0,
+    };
+    let PtyPair { master, slave } = pty_system.openpty(size).context("failed to open pty")?;
+
+    let mut command = CommandBuilder::new(&launch.program);
+    for arg in &launch.args {
+        command.arg(arg);
+    }
+
+    let child = slave
+        .spawn_command(command)
+        .context("failed to spawn shell process")?;
+    let mut reader = master
+        .try_clone_reader()
+        .context("failed to clone pty reader")?;
+    let writer = master
+        .take_writer()
+        .context("failed to acquire pty writer")?;
+    let entry = Arc::new(PtyEntry::new(id.clone(), master, writer, child));
+
+    start_reader(app.clone(), state.clone(), entry.clone(), reader);
+    state.insert_terminal(id.clone(), entry);
+    Ok(SpawnTerminalResponse {
+        shell_label: launch.label,
+        supports_wsl: launch.supports_wsl,
+    })
+}
+
+fn start_reader(
+    app: AppHandle,
+    state: TerminalState,
+    entry: Arc<PtyEntry>,
+    mut reader: Box<dyn Read + Send>,
+) {
+    let id = entry.id.clone();
+    std::thread::spawn(move || {
+        let mut buffer = [0u8; 8192];
+        loop {
+            match reader.read(&mut buffer) {
+                Ok(0) => {
+                    finalize_terminal(&app, &state, &id, Some("process exited".into()));
+                    break;
+                }
+                Ok(size) => {
+                    let encoded = general_purpose::STANDARD.encode(&buffer[..size]);
+                    let payload = TerminalChunk {
+                        id: id.clone(),
+                        data: encoded,
+                    };
+                    if app.emit_all("terminal://data", &payload).is_err() {
+                        break;
+                    }
+                }
+                Err(err) => {
+                    let message = format!("Failed to read terminal output: {err}");
+                    emit_error(&app, Some(id.clone()), &message);
+                    finalize_terminal(&app, &state, &id, Some(message));
+                    break;
+                }
+            }
+        }
+    });
+}
+
+#[tauri::command]
+pub fn write_to_terminal(
+    state: tauri::State<'_, TerminalState>,
+    id: String,
+    data: Vec<u8>,
+) -> Result<(), String> {
+    let Some(entry) = state.get_terminal(&id) else {
+        return Err(format!("terminal {id} not found"));
+    };
+    entry
+        .write(&data)
+        .map_err(|err| format!("write failed: {err}"))
+}
+
+#[tauri::command]
+pub fn resize_terminal(
+    state: tauri::State<'_, TerminalState>,
+    id: String,
+    cols: u16,
+    rows: u16,
+) -> Result<(), String> {
+    let Some(entry) = state.get_terminal(&id) else {
+        return Err(format!("terminal {id} not found"));
+    };
+    entry
+        .resize(cols, rows)
+        .map_err(|err| format!("resize failed: {err}"))
+}
+
+#[tauri::command]
+pub fn send_interrupt(state: tauri::State<'_, TerminalState>, id: String) -> Result<(), String> {
+    let Some(entry) = state.get_terminal(&id) else {
+        return Err(format!("terminal {id} not found"));
+    };
+    entry
+        .write(&[0x03])
+        .map_err(|err| format!("interrupt failed: {err}"))
+}
+
+#[tauri::command]
+pub fn close_terminal(
+    app: AppHandle,
+    state: tauri::State<'_, TerminalState>,
+    id: String,
+) -> Result<(), String> {
+    if let Some(entry) = state.take_terminal(&id) {
+        if let Err(error) = entry.kill() {
+            emit_error(
+                &app,
+                Some(id.clone()),
+                format!("failed to kill terminal: {error}"),
+            );
+        }
+        let status = entry.wait_exit();
+        emit_exit_event(&app, &id, status, Some("terminal closed".into()));
+        Ok(())
+    } else {
+        Err(format!("terminal {id} not found"))
+    }
+}
+
+#[tauri::command]
+pub async fn start_engine_stream(
+    app: AppHandle,
+    state: tauri::State<'_, TerminalState>,
+    id: String,
+) -> Result<(), String> {
+    if state.has_engine(&id) {
+        return Ok(());
+    }
+    let handle = spawn_engine_stream(app.clone(), state.clone(), id.clone());
+    state.insert_engine(id.clone(), handle);
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn stop_engine_stream(
+    state: tauri::State<'_, TerminalState>,
+    id: String,
+) -> Result<(), String> {
+    if let Some(handle) = state.take_engine(&id) {
+        handle.cancel.cancel();
+        tauri::async_runtime::spawn(async move {
+            let _ = handle.task.await;
+        });
+    }
+    Ok(())
+}
+
+fn spawn_engine_stream(app: AppHandle, state: TerminalState, id: String) -> EngineHandle {
+    let cancel = CancellationToken::new();
+    let token = cancel.clone();
+    let task = tauri::async_runtime::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_secs(1));
+        let mut seq: u64 = 0;
+        while !token.is_cancelled() {
+            interval.tick().await;
+            seq += 1;
+            let heartbeat = EngineHeartbeat::new(seq);
+            match serde_json::to_string(&heartbeat) {
+                Ok(json) => {
+                    let line = format!("{json}\n");
+                    let payload = TerminalChunk {
+                        id: id.clone(),
+                        data: general_purpose::STANDARD.encode(line.as_bytes()),
+                    };
+                    if let Err(err) = app.emit_all("terminal://data", &payload) {
+                        warn!("failed to emit engine heartbeat: {err}");
+                        break;
+                    }
+                }
+                Err(err) => {
+                    emit_error(
+                        &app,
+                        Some(id.clone()),
+                        format!("engine stream error: {err}"),
+                    );
+                    break;
+                }
+            }
+        }
+        let _ = app.emit_all(
+            "terminal://exit",
+            &TerminalExitEvent {
+                id: id.clone(),
+                code: None,
+                signal: None,
+                message: Some("engine stream stopped".into()),
+            },
+        );
+        state.take_engine(&id);
+    });
+    EngineHandle { cancel, task }
+}
+
+#[derive(Debug, Serialize)]
+struct EngineHeartbeat {
+    seq: u64,
+    timestamp: f64,
+    level: &'static str,
+    message: String,
+}
+
+impl EngineHeartbeat {
+    fn new(seq: u64) -> Self {
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|duration| duration.as_secs_f64())
+            .unwrap_or_default();
+        Self {
+            seq,
+            timestamp,
+            level: "info",
+            message: format!("engine heartbeat {seq}"),
+        }
+    }
+}
+
+fn emit_exit_event(app: &AppHandle, id: &str, status: Option<ExitStatus>, message: Option<String>) {
+    let (code, signal) = status
+        .map(|status| (status.code(), status.signal().map(|s| s.to_string())))
+        .unwrap_or((None, None));
+    let _ = app.emit_all(
+        "terminal://exit",
+        &TerminalExitEvent {
+            id: id.to_string(),
+            code,
+            signal,
+            message,
+        },
+    );
+}
+
+fn finalize_terminal(app: &AppHandle, state: &TerminalState, id: &str, message: Option<String>) {
+    if let Some(entry) = state.take_terminal(id) {
+        let status = entry.wait_exit();
+        emit_exit_event(app, id, status, message);
+    }
+}
+
+fn emit_error(app: &AppHandle, id: Option<String>, message: impl Into<String>) {
+    let payload = TerminalErrorEvent {
+        id,
+        message: message.into(),
+    };
+    let _ = app.emit_all("terminal://error", &payload);
+}
+
+fn resolve_shell(use_wsl: bool) -> Result<ShellLaunch> {
+    if cfg!(target_os = "windows") {
+        resolve_windows_shell(use_wsl)
+    } else {
+        resolve_unix_shell()
+    }
+}
+
+fn resolve_windows_shell(use_wsl: bool) -> Result<ShellLaunch> {
+    let supports_wsl = which::which("wsl").is_ok() || which::which("wsl.exe").is_ok();
+    if use_wsl {
+        if !supports_wsl {
+            return Err(anyhow!("WSL requested but no wsl executable was found"));
+        }
+        let wsl_path = which::which("wsl").or_else(|_| which::which("wsl.exe"));
+        let program = wsl_path
+            .as_ref()
+            .map(|path| path.to_string_lossy().to_string())
+            .unwrap_or_else(|| "wsl".to_string());
+        return Ok(ShellLaunch {
+            program,
+            args: vec!["-e".into(), "bash".into()],
+            label: "wsl -e bash".into(),
+            supports_wsl,
+        });
+    }
+    let candidates = ["pwsh.exe", "pwsh", "powershell.exe", "powershell"];
+    for candidate in candidates {
+        if let Ok(path) = which::which(candidate) {
+            return Ok(ShellLaunch {
+                label: format!(
+                    "{}",
+                    path.file_name()
+                        .map(|s| s.to_string_lossy())
+                        .unwrap_or_else(|| candidate.into())
+                ),
+                program: path.to_string_lossy().to_string(),
+                args: vec![],
+                supports_wsl,
+            });
+        }
+    }
+    Err(anyhow!(
+        "No PowerShell executable found. Install pwsh or powershell, or enable WSL."
+    ))
+}
+
+fn resolve_unix_shell() -> Result<ShellLaunch> {
+    let mut candidates = Vec::new();
+    if let Ok(shell_env) = std::env::var("SHELL") {
+        candidates.push(shell_env);
+    }
+    candidates.extend([
+        "/bin/zsh".to_string(),
+        "/bin/bash".to_string(),
+        "/bin/sh".to_string(),
+    ]);
+    for candidate in candidates {
+        if candidate.is_empty() {
+            continue;
+        }
+        let path = if candidate.starts_with('/') {
+            let candidate_path = std::path::Path::new(&candidate);
+            if candidate_path.exists() {
+                candidate_path.to_path_buf()
+            } else {
+                continue;
+            }
+        } else if let Ok(found) = which::which(&candidate) {
+            found
+        } else {
+            continue;
+        };
+        return Ok(ShellLaunch {
+            label: path
+                .file_name()
+                .map(|name| name.to_string_lossy().to_string())
+                .unwrap_or_else(|| candidate.clone()),
+            program: path.to_string_lossy().to_string(),
+            args: vec![],
+            supports_wsl: false,
+        });
+    }
+    Err(anyhow!(
+        "No suitable shell found (checked SHELL, zsh, bash, sh)."
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn unix_shell_prefers_env() {
+        let launch = resolve_unix_shell().unwrap();
+        assert!(!launch.program.is_empty());
+    }
+
+    #[test]
+    fn heartbeat_timestamp_is_non_zero() {
+        let heartbeat = EngineHeartbeat::new(1);
+        assert!(heartbeat.timestamp >= 0.0);
+        assert_eq!(heartbeat.seq, 1);
+    }
+}

--- a/apps/ade-tauri/src-tauri/src/terminal.rs
+++ b/apps/ade-tauri/src-tauri/src/terminal.rs
@@ -145,11 +145,8 @@ impl PtyEntry {
     }
 
     fn wait_exit(&self) -> Option<ExitStatus> {
-        match self.child.lock().try_wait() {
-            Ok(Some(status)) => Some(status),
-            Ok(None) => self.child.lock().wait().ok(),
-            Err(_) => None,
-        }
+        // Blocking wait is acceptable here—if the process already exited, this returns immediately.
+        self.child.lock().wait().ok()
     }
 }
 

--- a/apps/ade-tauri/src-tauri/tauri.conf.json
+++ b/apps/ade-tauri/src-tauri/tauri.conf.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "build": {
+    "beforeDevCommand": "pnpm --filter @ade/tauri-app dev",
+    "beforeBuildCommand": "pnpm --filter @ade/tauri-app build",
+    "devPath": "http://localhost:5173",
+    "distDir": "../dist"
+  },
+  "package": {
+    "productName": "ADE",
+    "version": "0.1.0"
+  },
+  "tauri": {
+    "bundle": {
+      "active": false
+    },
+    "windows": [
+      {
+        "fullscreen": false,
+        "resizable": true,
+        "title": "ADE Terminals"
+      }
+    ]
+  }
+}

--- a/apps/ade-tauri/src/App.tsx
+++ b/apps/ade-tauri/src/App.tsx
@@ -1,0 +1,54 @@
+import { useCallback, useMemo, useState } from 'react';
+import TerminalsPane from './components/TerminalsPane';
+import { ToastStack, Toast } from './components/ToastStack';
+
+export interface ToastEntry {
+  id: string;
+  title: string;
+  message: string;
+}
+
+const App = () => {
+  const [toasts, setToasts] = useState<ToastEntry[]>([]);
+  const pushToast = useCallback((toast: Omit<ToastEntry, 'id'>) => {
+    setToasts((current) => {
+      const entry: ToastEntry = {
+        ...toast,
+        id: `${Date.now()}-${Math.random().toString(16).slice(2)}`,
+      };
+      return [...current.slice(-3), entry];
+    });
+  }, []);
+
+  const dismiss = useCallback((id: string) => {
+    setToasts((current) => current.filter((toast) => toast.id !== id));
+  }, []);
+
+  const terminalHandlers = useMemo(
+    () => ({
+      onError: (message: string) =>
+        pushToast({ title: 'Terminal error', message }),
+      onInfo: (message: string) =>
+        pushToast({ title: 'Terminal info', message }),
+    }),
+    [pushToast],
+  );
+
+  return (
+    <div className="app-shell">
+      <header className="app-shell__header">
+        <h1 className="app-shell__title">ADE • Terminals</h1>
+      </header>
+      <main className="app-shell__content">
+        <TerminalsPane handlers={terminalHandlers} />
+      </main>
+      <ToastStack>
+        {toasts.map((toast) => (
+          <Toast key={toast.id} toast={toast} onDismiss={dismiss} />
+        ))}
+      </ToastStack>
+    </div>
+  );
+};
+
+export default App;

--- a/apps/ade-tauri/src/components/TerminalSurface.tsx
+++ b/apps/ade-tauri/src/components/TerminalSurface.tsx
@@ -1,0 +1,35 @@
+import type { ReactNode } from 'react';
+import type { TerminalStatus } from '../hooks/useTerminal';
+
+interface TerminalSurfaceProps {
+  mount: (node: HTMLDivElement | null) => void;
+  status: TerminalStatus;
+  label: string;
+  overlay?: ReactNode;
+}
+
+const statusLabel = (status: TerminalStatus) => {
+  switch (status) {
+    case 'starting':
+      return 'Starting…';
+    case 'closed':
+      return 'Session closed';
+    default:
+      return null;
+  }
+};
+
+export const TerminalSurface = ({ mount, status, label, overlay }: TerminalSurfaceProps) => {
+  const message = statusLabel(status);
+  return (
+    <div className="terminal-surface">
+      <div className="terminal-surface__canvas" aria-label={label} ref={mount} />
+      {message && (
+        <div className="terminal-surface__overlay" role="status" aria-live="polite">
+          {message}
+        </div>
+      )}
+      {overlay}
+    </div>
+  );
+};

--- a/apps/ade-tauri/src/components/TerminalsPane.spec.tsx
+++ b/apps/ade-tauri/src/components/TerminalsPane.spec.tsx
@@ -1,0 +1,80 @@
+import { render, screen } from '@testing-library/react';
+import { vi, type Mock } from 'vitest';
+import TerminalsPane from './TerminalsPane';
+
+vi.mock('../hooks/useTerminal', () => ({
+  useTerminal: vi.fn(),
+}));
+
+import { useTerminal } from '../hooks/useTerminal';
+
+const mockedUseTerminal = useTerminal as unknown as Mock;
+
+describe('TerminalsPane', () => {
+  beforeEach(() => {
+    mockedUseTerminal.mockReset();
+  });
+
+  const baseHandlers = {
+    onError: vi.fn(),
+    onInfo: vi.fn(),
+  };
+
+  type TerminalSnapshot = {
+    mount: (node: HTMLDivElement | null) => void;
+    status: 'starting' | 'ready' | 'closed';
+    error: string | null;
+    lastExit: string | null;
+    shellLabel: string | null;
+    supportsWsl: boolean;
+    isResolving: boolean;
+    sendInterrupt: () => Promise<void>;
+  };
+
+  const snapshot = (overrides: Partial<TerminalSnapshot> = {}): TerminalSnapshot => ({
+    mount: vi.fn(),
+    status: 'ready',
+    error: null,
+    lastExit: null,
+    shellLabel: 'bash',
+    supportsWsl: false,
+    isResolving: false,
+    sendInterrupt: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  });
+
+  it('hides the WSL toggle when support flag is false', () => {
+    mockedUseTerminal
+      .mockReturnValueOnce(snapshot())
+      .mockReturnValueOnce(snapshot({ shellLabel: 'engine', supportsWsl: false }));
+
+    render(<TerminalsPane handlers={baseHandlers} />);
+
+    expect(screen.queryByText(/Use WSL bash/i)).not.toBeInTheDocument();
+  });
+
+  it('shows the WSL toggle when support flag is true', () => {
+    mockedUseTerminal
+      .mockReturnValueOnce(snapshot({ supportsWsl: true, isResolving: true }))
+      .mockReturnValueOnce(snapshot({ shellLabel: 'engine', supportsWsl: false }));
+
+    render(<TerminalsPane handlers={baseHandlers} />);
+
+    const toggle = screen.getByLabelText(/Use WSL bash/i) as HTMLInputElement;
+    expect(toggle).toBeInTheDocument();
+    expect(toggle.disabled).toBe(true);
+  });
+
+  it('sends an interrupt when the button is pressed', async () => {
+    const sendInterrupt = vi.fn().mockResolvedValue(undefined);
+    mockedUseTerminal
+      .mockReturnValueOnce(snapshot({ sendInterrupt }))
+      .mockReturnValueOnce(snapshot({ shellLabel: 'engine', supportsWsl: false }));
+
+    render(<TerminalsPane handlers={baseHandlers} />);
+
+    await screen.findByRole('button', { name: /Send Ctrl\+C/i });
+    screen.getByRole('button', { name: /Send Ctrl\+C/i }).click();
+    expect(sendInterrupt).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ade-tauri/src/components/TerminalsPane.tsx
+++ b/apps/ade-tauri/src/components/TerminalsPane.tsx
@@ -1,0 +1,148 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useTerminal } from '../hooks/useTerminal';
+import { TerminalSurface } from './TerminalSurface';
+
+interface TerminalHandlers {
+  onError: (message: string) => void;
+  onInfo: (message: string) => void;
+}
+
+interface TerminalsPaneProps {
+  handlers: TerminalHandlers;
+}
+
+const TerminalsPane = ({ handlers }: TerminalsPaneProps) => {
+  const [useWsl, setUseWsl] = useState(false);
+  const meTerminal = useTerminal({
+    id: 'me',
+    mode: 'pty',
+    useWsl,
+    onError: handlers.onError,
+    onInfo: handlers.onInfo,
+  });
+  const engineTerminal = useTerminal({
+    id: 'engine',
+    mode: 'engine',
+    onError: handlers.onError,
+    onInfo: handlers.onInfo,
+  });
+
+  const engineMeta = useMemo(
+    () => [
+      `source: heartbeat`,
+      engineTerminal.status ? `status: ${engineTerminal.status}` : 'status: starting',
+    ],
+    [engineTerminal.status],
+  );
+
+  const meMeta = useMemo(
+    () => {
+      const base = [`shell: ${meTerminal.shellLabel ?? 'resolving'}`];
+      if (meTerminal.lastExit) {
+        base.push(`exit: ${meTerminal.lastExit}`);
+      }
+      return base;
+    },
+    [meTerminal.shellLabel, meTerminal.lastExit],
+  );
+
+  const toggleRef = useRef<HTMLInputElement | null>(null);
+  const syncToggle = useCallback(() => {
+    if (!toggleRef.current) {
+      return;
+    }
+    toggleRef.current.indeterminate = meTerminal.isResolving;
+  }, [meTerminal.isResolving]);
+
+  useEffect(syncToggle, [syncToggle]);
+
+  useEffect(() => {
+    if (!meTerminal.isResolving) {
+      return;
+    }
+    handlers.onInfo('Resolving shell executable…');
+  }, [handlers, meTerminal.isResolving]);
+
+  useEffect(() => {
+    if (!meTerminal.error) {
+      return;
+    }
+    handlers.onError(meTerminal.error);
+  }, [handlers, meTerminal.error]);
+
+  useEffect(() => {
+    if (!engineTerminal.error) {
+      return;
+    }
+    handlers.onError(engineTerminal.error);
+  }, [handlers, engineTerminal.error]);
+
+  return (
+    <div className="terminals-pane">
+      <section className="terminal-card" aria-label="Interactive terminal">
+        <header className="terminal-card__header">
+          <h2 className="terminal-card__title">Me</h2>
+          <div className="terminal-card__actions">
+            <button
+              type="button"
+              className="terminal-card__button"
+              onClick={() => {
+                void meTerminal.sendInterrupt();
+              }}
+              disabled={meTerminal.status !== 'ready'}
+            >
+              Send Ctrl+C
+            </button>
+            {meMeta.length > 0 && (
+              <div className="terminal-meta" aria-live="polite">
+                {meMeta.map((item) => (
+                  <span key={item}>{item}</span>
+                ))}
+              </div>
+            )}
+            {meTerminal.supportsWsl && (
+              <label className="toggle">
+                <input
+                  ref={toggleRef}
+                  type="checkbox"
+                  checked={useWsl}
+                  onChange={(event) => setUseWsl(event.target.checked)}
+                  disabled={meTerminal.isResolving}
+                />
+                Use WSL bash
+              </label>
+            )}
+          </div>
+        </header>
+        <div className="terminal-card__body">
+          <TerminalSurface
+            label="Interactive terminal"
+            mount={meTerminal.mount}
+            status={meTerminal.status}
+          />
+        </div>
+      </section>
+      <section className="terminal-card" aria-label="Engine terminal">
+        <header className="terminal-card__header">
+          <h2 className="terminal-card__title">Engine</h2>
+          {engineMeta.length > 0 && (
+            <div className="terminal-meta" aria-live="polite">
+              {engineMeta.map((item) => (
+                <span key={item}>{item}</span>
+              ))}
+            </div>
+          )}
+        </header>
+        <div className="terminal-card__body">
+          <TerminalSurface
+            label="Engine terminal"
+            mount={engineTerminal.mount}
+            status={engineTerminal.status}
+          />
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default TerminalsPane;

--- a/apps/ade-tauri/src/components/ToastStack.tsx
+++ b/apps/ade-tauri/src/components/ToastStack.tsx
@@ -22,20 +22,12 @@ export const Toast = ({ toast, onDismiss }: ToastProps) => {
       <p className="toast__message">{toast.message}</p>
       <button
         type="button"
-        aria-label="Dismiss notification"
+        className="toast__dismiss"
+        aria-label="Dismiss toast"
         onClick={() => onDismiss(toast.id)}
-        style={{
-          position: 'absolute',
-          top: '0.35rem',
-          right: '0.5rem',
-          background: 'transparent',
-          color: 'var(--text-muted)',
-          border: 'none',
-          cursor: 'pointer',
-          fontSize: '0.75rem',
-        }}
+        title="Dismiss"
       >
-        ✕
+        ×
       </button>
     </div>
   );

--- a/apps/ade-tauri/src/components/ToastStack.tsx
+++ b/apps/ade-tauri/src/components/ToastStack.tsx
@@ -1,0 +1,42 @@
+import { PropsWithChildren } from 'react';
+import type { ToastEntry } from '../App';
+
+interface ToastProps {
+  toast: ToastEntry;
+  onDismiss: (id: string) => void;
+}
+
+export const ToastStack = ({ children }: PropsWithChildren) => {
+  if (!children) {
+    return null;
+  }
+  return <div className="toast-stack">{children}</div>;
+};
+
+export const Toast = ({ toast, onDismiss }: ToastProps) => {
+  return (
+    <div className="toast" role="status">
+      <div className="toast__header">
+        <h2 className="toast__title">{toast.title}</h2>
+      </div>
+      <p className="toast__message">{toast.message}</p>
+      <button
+        type="button"
+        aria-label="Dismiss notification"
+        onClick={() => onDismiss(toast.id)}
+        style={{
+          position: 'absolute',
+          top: '0.35rem',
+          right: '0.5rem',
+          background: 'transparent',
+          color: 'var(--text-muted)',
+          border: 'none',
+          cursor: 'pointer',
+          fontSize: '0.75rem',
+        }}
+      >
+        ✕
+      </button>
+    </div>
+  );
+};

--- a/apps/ade-tauri/src/hooks/useTerminal.ts
+++ b/apps/ade-tauri/src/hooks/useTerminal.ts
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { invoke } from '@tauri-apps/api/tauri';
 import { listen } from '@tauri-apps/api/event';
-import { Terminal } from 'xterm';
-import { FitAddon } from 'xterm-addon-fit';
+import { Terminal } from '@xterm/xterm';
+import { FitAddon } from '@xterm/addon-fit';
 
 interface TerminalChunk {
   id: string;

--- a/apps/ade-tauri/src/hooks/useTerminal.ts
+++ b/apps/ade-tauri/src/hooks/useTerminal.ts
@@ -1,0 +1,304 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { invoke } from '@tauri-apps/api/tauri';
+import { listen } from '@tauri-apps/api/event';
+import { Terminal } from 'xterm';
+import { FitAddon } from 'xterm-addon-fit';
+
+interface TerminalChunk {
+  id: string;
+  data: string;
+}
+
+interface TerminalExit {
+  id: string;
+  code: number | null;
+  signal?: string | null;
+  message?: string | null;
+}
+
+interface TerminalErrorPayload {
+  id?: string | null;
+  message: string;
+}
+
+type TerminalMode = 'pty' | 'engine';
+
+export type TerminalStatus = 'starting' | 'ready' | 'closed';
+
+interface UseTerminalOptions {
+  id: string;
+  mode: TerminalMode;
+  onError: (message: string) => void;
+  onInfo: (message: string) => void;
+  useWsl?: boolean;
+}
+
+const base64ToString = (chunk: string) => {
+  try {
+    return decodeURIComponent(
+      atob(chunk)
+        .split('')
+        .map((c) => `%${`00${c.charCodeAt(0).toString(16)}`.slice(-2)}`)
+        .join(''),
+    );
+  } catch (_error) {
+    return atob(chunk);
+  }
+};
+
+const stringToUint8 = (value: string) => new TextEncoder().encode(value);
+
+export const useTerminal = ({ id, mode, onError, onInfo, useWsl }: UseTerminalOptions) => {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const terminalRef = useRef<Terminal | null>(null);
+  const fitAddonRef = useRef<FitAddon | null>(null);
+  const frameTokenRef = useRef<number | null>(null);
+  const bufferRef = useRef<string[]>([]);
+  const [status, setStatus] = useState<TerminalStatus>('starting');
+  const [shellLabel, setShellLabel] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [lastExit, setLastExit] = useState<string | null>(null);
+  const [supportsWsl, setSupportsWsl] = useState<boolean>(false);
+  const [isResolving, setIsResolving] = useState(false);
+
+  const flushBuffer = useCallback(() => {
+    if (!terminalRef.current) {
+      bufferRef.current = [];
+      frameTokenRef.current = null;
+      return;
+    }
+    const chunk = bufferRef.current.join('');
+    bufferRef.current = [];
+    if (chunk.length > 0) {
+      terminalRef.current.write(chunk);
+    }
+    frameTokenRef.current = null;
+  }, []);
+
+  const scheduleFlush = useCallback(() => {
+    if (frameTokenRef.current != null) {
+      return;
+    }
+    frameTokenRef.current = requestAnimationFrame(flushBuffer);
+  }, [flushBuffer]);
+
+  const enqueue = useCallback(
+    (payload: string) => {
+      bufferRef.current.push(payload);
+      if (bufferRef.current.length > 128) {
+        flushBuffer();
+        return;
+      }
+      scheduleFlush();
+    },
+    [flushBuffer, scheduleFlush],
+  );
+
+  const mount = useCallback((node: HTMLDivElement | null) => {
+    containerRef.current = node;
+    if (node && terminalRef.current) {
+      terminalRef.current.open(node);
+      fitAddonRef.current?.fit();
+    }
+  }, []);
+
+  const emitResize = useCallback(() => {
+    const terminal = terminalRef.current;
+    if (!terminal) {
+      return;
+    }
+    const cols = terminal.cols;
+    const rows = terminal.rows;
+    if (mode !== 'pty') {
+      return;
+    }
+    invoke('resize_terminal', { id, cols, rows }).catch((resizeError) => {
+      const message = resizeError instanceof Error ? resizeError.message : String(resizeError);
+      onError(`Failed to resize terminal: ${message}`);
+    });
+  }, [id, mode, onError]);
+
+  const configureTerminal = useCallback(() => {
+    if (terminalRef.current) {
+      return;
+    }
+    const terminal = new Terminal({
+      convertEol: true,
+      cursorBlink: true,
+      fontFamily: getComputedStyle(document.documentElement).fontFamily,
+      theme: {
+        background: '#0f1115',
+        foreground: '#e7ecf4',
+        cursor: '#3b82f6',
+      },
+    });
+    terminalRef.current = terminal;
+    const fitAddon = new FitAddon();
+    fitAddonRef.current = fitAddon;
+    terminal.loadAddon(fitAddon);
+    if (containerRef.current) {
+      terminal.open(containerRef.current);
+      queueMicrotask(() => {
+        fitAddon.fit();
+        emitResize();
+      });
+    }
+    const resizeObserver = new ResizeObserver(() => {
+      if (!fitAddonRef.current) {
+        return;
+      }
+      requestAnimationFrame(() => {
+        fitAddonRef.current?.fit();
+        emitResize();
+      });
+    });
+    if (containerRef.current) {
+      resizeObserver.observe(containerRef.current);
+    }
+    const disposeResize = () => resizeObserver.disconnect();
+
+    const subscriptions = [] as Array<() => void>;
+    if (mode === 'pty') {
+      subscriptions.push(
+        terminal.onData((input) => {
+          invoke('write_to_terminal', { id, data: Array.from(stringToUint8(input)) })
+            .catch((writeError) => {
+              const message =
+                writeError instanceof Error ? writeError.message : String(writeError);
+              onError(`Failed to write to terminal: ${message}`);
+            });
+        }).dispose,
+      );
+    }
+
+    const dataListener = listen<TerminalChunk>('terminal://data', (event) => {
+      if (event.payload.id !== id) {
+        return;
+      }
+      enqueue(base64ToString(event.payload.data));
+      setStatus('ready');
+    });
+    const exitListener = listen<TerminalExit>('terminal://exit', (event) => {
+      if (event.payload.id !== id) {
+        return;
+      }
+      const code =
+        typeof event.payload.code === 'number' ? event.payload.code.toString() : 'unknown';
+      const signal = event.payload.signal ?? undefined;
+      const message = event.payload.message;
+      const line = signal ? `${signal}` : `code ${code}`;
+      setLastExit(line);
+      setStatus('closed');
+      if (message) {
+        onInfo(message);
+      }
+    });
+    const errorListener = listen<TerminalErrorPayload>('terminal://error', (event) => {
+      if (event.payload.id && event.payload.id !== id) {
+        return;
+      }
+      const message = event.payload.message;
+      setError(message);
+      onError(message);
+    });
+
+    const listeners = [dataListener, exitListener, errorListener];
+
+    return () => {
+      listeners.forEach((listenerPromise) => {
+        listenerPromise.then((unsubscribe) => unsubscribe());
+      });
+      subscriptions.forEach((dispose) => dispose());
+      disposeResize();
+      terminal.dispose();
+      terminalRef.current = null;
+      fitAddonRef.current = null;
+    };
+  }, [emitResize, enqueue, id, mode, onError, onInfo]);
+
+  useEffect(() => {
+    configureTerminal();
+  }, [configureTerminal]);
+
+  const startEngine = useCallback(async () => {
+    setStatus('starting');
+    setLastExit(null);
+    try {
+      await invoke('start_engine_stream', { id });
+      setShellLabel('engine heartbeat');
+      setSupportsWsl(false);
+      setError(null);
+      setStatus('ready');
+    } catch (engineError) {
+      const message = engineError instanceof Error ? engineError.message : String(engineError);
+      setError(message);
+      onError(message);
+    }
+  }, [id, onError]);
+
+  const startShell = useCallback(async () => {
+    setStatus('starting');
+    setLastExit(null);
+    setShellLabel(null);
+    setSupportsWsl(false);
+    setIsResolving(true);
+    try {
+      const response = await invoke<{
+        shellLabel: string;
+        supportsWsl: boolean;
+      }>('spawn_terminal', {
+        id,
+        cols: terminalRef.current?.cols,
+        rows: terminalRef.current?.rows,
+        useWsl: Boolean(useWsl),
+      });
+      setShellLabel(response.shellLabel);
+      setSupportsWsl(response.supportsWsl);
+      setError(null);
+      setStatus('ready');
+    } catch (spawnError) {
+      const message = spawnError instanceof Error ? spawnError.message : String(spawnError);
+      setError(message);
+      onError(message);
+    } finally {
+      setIsResolving(false);
+    }
+  }, [id, onError, useWsl]);
+
+  const sendInterrupt = useCallback(async () => {
+    if (mode !== 'pty') {
+      return;
+    }
+    try {
+      await invoke('send_interrupt', { id });
+      onInfo(`Sent Ctrl+C to ${id}`);
+    } catch (interruptError) {
+      const message =
+        interruptError instanceof Error ? interruptError.message : String(interruptError);
+      onError(`Failed to send Ctrl+C: ${message}`);
+    }
+  }, [id, mode, onError, onInfo]);
+
+  useEffect(() => {
+    if (mode === 'engine') {
+      startEngine();
+      return () => {
+        invoke('stop_engine_stream', { id }).catch(() => undefined);
+      };
+    }
+    startShell();
+    return () => {
+      invoke('close_terminal', { id }).catch(() => undefined);
+    };
+  }, [id, mode, startEngine, startShell]);
+  return {
+    mount,
+    status,
+    error,
+    lastExit,
+    shellLabel,
+    supportsWsl,
+    isResolving,
+    sendInterrupt,
+  };
+};

--- a/apps/ade-tauri/src/hooks/useTerminal.ts
+++ b/apps/ade-tauri/src/hooks/useTerminal.ts
@@ -34,15 +34,12 @@ interface UseTerminalOptions {
 }
 
 const base64ToString = (chunk: string) => {
+  const bin = atob(chunk);
   try {
-    return decodeURIComponent(
-      atob(chunk)
-        .split('')
-        .map((c) => `%${`00${c.charCodeAt(0).toString(16)}`.slice(-2)}`)
-        .join(''),
-    );
+    const bytes = Uint8Array.from(bin, (char) => char.charCodeAt(0));
+    return new TextDecoder('utf-8', { fatal: true }).decode(bytes);
   } catch (_error) {
-    return atob(chunk);
+    return bin;
   }
 };
 
@@ -216,8 +213,9 @@ export const useTerminal = ({ id, mode, onError, onInfo, useWsl }: UseTerminalOp
     };
   }, [emitResize, enqueue, id, mode, onError, onInfo]);
 
+  // Initialize xterm and related listeners; cleanup prevents StrictMode leaks.
   useEffect(() => {
-    configureTerminal();
+    return configureTerminal();
   }, [configureTerminal]);
 
   const startEngine = useCallback(async () => {

--- a/apps/ade-tauri/src/main.tsx
+++ b/apps/ade-tauri/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './styles.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/apps/ade-tauri/src/styles.css
+++ b/apps/ade-tauri/src/styles.css
@@ -1,0 +1,198 @@
+:root {
+  color-scheme: dark;
+  --background: #0f1115;
+  --surface: #161920;
+  --border: #282d39;
+  --text: #e7ecf4;
+  --text-muted: #9aa0b5;
+  --accent: #3b82f6;
+  --danger: #ef4444;
+  font-family: 'JetBrains Mono', 'Fira Code', Consolas, monospace;
+}
+
+body,
+html,
+#root {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  background: var(--background);
+  color: var(--text);
+}
+
+body {
+  display: flex;
+}
+
+#root {
+  flex: 1;
+  display: flex;
+}
+
+.app-shell {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+.app-shell__header {
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--border);
+  background: var(--surface);
+}
+
+.app-shell__title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.app-shell__content {
+  flex: 1;
+  display: flex;
+  overflow: hidden;
+}
+
+.terminals-pane {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 1px;
+  width: 100%;
+  height: 100%;
+  background: var(--border);
+}
+
+.terminal-card {
+  display: flex;
+  flex-direction: column;
+  background: var(--surface);
+  border: 1px solid transparent;
+}
+
+.terminal-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.terminal-card__title {
+  font-weight: 600;
+  margin: 0;
+}
+
+.terminal-card__actions {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.terminal-card__button {
+  appearance: none;
+  border: 1px solid var(--border);
+  background: rgba(59, 130, 246, 0.1);
+  color: var(--text);
+  font-family: inherit;
+  font-size: 0.75rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.terminal-card__button:hover:not(:disabled) {
+  background: rgba(59, 130, 246, 0.2);
+  border-color: rgba(59, 130, 246, 0.6);
+}
+
+.terminal-card__button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.terminal-card__body {
+  flex: 1;
+  position: relative;
+  overflow: hidden;
+}
+
+.terminal-card__body .xterm {
+  height: 100%;
+  padding: 0.5rem;
+}
+
+.terminal-card__body .xterm-viewport {
+  background: transparent !important;
+}
+
+.terminal-surface {
+  position: relative;
+  height: 100%;
+}
+
+.terminal-surface__canvas {
+  height: 100%;
+}
+
+.terminal-surface__overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  background: rgba(15, 17, 21, 0.68);
+  pointer-events: none;
+}
+
+.toast-stack {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.toast {
+  background: rgba(15, 17, 21, 0.9);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--danger);
+  padding: 0.75rem 1rem;
+  min-width: 240px;
+  max-width: 320px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
+}
+
+.toast__title {
+  margin: 0;
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.toast__message {
+  margin: 0.25rem 0 0;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.terminal-meta {
+  display: flex;
+  gap: 0.75rem;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.toggle input {
+  accent-color: var(--accent);
+}

--- a/apps/ade-tauri/src/styles.css
+++ b/apps/ade-tauri/src/styles.css
@@ -178,6 +178,23 @@ body {
   color: var(--text-muted);
 }
 
+.toast__dismiss {
+  position: absolute;
+  top: 0.35rem;
+  right: 0.5rem;
+  background: transparent;
+  color: var(--text-muted);
+  border: none;
+  cursor: pointer;
+  font-size: 0.75rem;
+  padding: 0;
+}
+
+.toast__dismiss:hover,
+.toast__dismiss:focus-visible {
+  color: var(--text);
+}
+
 .terminal-meta {
   display: flex;
   gap: 0.75rem;

--- a/apps/ade-tauri/tsconfig.json
+++ b/apps/ade-tauri/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "baseUrl": "./",
+    "types": ["vitest", "vite/client"],
+    "jsx": "react-jsx"
+  },
+  "include": ["src", "vite.config.ts", "vitest.config.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/apps/ade-tauri/vite.config.ts
+++ b/apps/ade-tauri/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+  },
+});

--- a/apps/ade-tauri/vitest.config.ts
+++ b/apps/ade-tauri/vitest.config.ts
@@ -6,5 +6,6 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     setupFiles: ['./vitest.setup.ts'],
+    globals: true,
   },
 });

--- a/apps/ade-tauri/vitest.config.ts
+++ b/apps/ade-tauri/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./vitest.setup.ts'],
+  },
+});

--- a/apps/ade-tauri/vitest.config.ts
+++ b/apps/ade-tauri/vitest.config.ts
@@ -6,6 +6,5 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     setupFiles: ['./vitest.setup.ts'],
-    globals: true,
   },
 });

--- a/apps/ade-tauri/vitest.setup.ts
+++ b/apps/ade-tauri/vitest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -1,0 +1,25 @@
+import { defineProject, defineWorkspace } from 'vitest/config';
+
+export default defineWorkspace([
+  defineProject({
+    test: {
+      name: 'core',
+      globals: true,
+      include: [
+        'packages/**/*.test.ts',
+        'packages/**/*.test.tsx',
+        'packages/**/*.spec.ts',
+        'packages/**/*.spec.tsx',
+      ],
+      exclude: ['apps/**', 'bo4/**', 'node_modules/**'],
+    },
+  }),
+  defineProject({
+    extends: './apps/ade-tauri/vitest.config.ts',
+    root: './apps/ade-tauri',
+    test: {
+      name: 'tauri-app',
+      include: ['src/**/*.spec.tsx'],
+    },
+  }),
+]);


### PR DESCRIPTION
## Summary
- port var2\u2019s tauri PTY backend and React dual-terminal interface into the repo (minus Cargo.lock per rules)
- add reusable TerminalSurface wrapper plus Send Ctrl+C control and scoped @xterm packages
- keep vitest smoke coverage for the pane and document local dev deps (jsdom, jest-dom) for the test run

## Testing
- pnpm --filter @ade/tauri-app test -- --globals --run